### PR TITLE
Fix diagnostics for generated node class components

### DIFF
--- a/src/lib/utils/FileFactory.ts
+++ b/src/lib/utils/FileFactory.ts
@@ -28,7 +28,7 @@ export class FileFactory {
 
     public addFile<T extends BscFile>(destPath: string, contents: string) {
         try {
-            return this.program.setFile<T>({ src: path.resolve(destPath), dest: destPath }, contents);
+            return this.program.setFile<T>(destPath, contents);
         } catch (error) {
             console.error(`Error adding framework file: ${destPath} : ${error.message}`);
         }

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -569,6 +569,26 @@ describe('MaestroPlugin', () => {
     });
 
     describe('node class tests', () => {
+
+        it('gives diagnostics for generated nodeclass components', () => {
+            plugin.afterProgramCreate(program);
+
+            program.setFile('source/VM.bs', `
+                @node("MyNodeClass", "Group")
+                class VM
+                    function new()
+                    end function
+                end class
+            `);
+            program.validate();
+            //the srcPath for this file should be relative to rootDir, not cwd
+            expect(
+                program.getFile('components/maestro/generated/MyNodeClass.xml').srcPath
+            ).to.eql(
+                s`${_rootDir}/components/maestro/generated/MyNodeClass.xml`
+            );
+        });
+
         it('parses a node class with no errors', async () => {
             plugin.afterProgramCreate(program);
             program.setFile('source/comp.bs', `


### PR DESCRIPTION
**Issue: `diagnosticFilters` were not working properly against the generated maestro files due to using destPath as the source path.**

Here is a video demonstrating before/after applying the fix:

https://github.com/user-attachments/assets/be1444ae-a70d-4c5b-afe4-2428f3787e22

shoutout to @TwitchBronBron for debugging this with me!